### PR TITLE
Fix issues with toml in Configuration.md

### DIFF
--- a/doc/src/Configuration.md
+++ b/doc/src/Configuration.md
@@ -53,7 +53,6 @@ customdnsrecords = [
     ]
     # list of locations to recursively read blocklists from (warning, every file found is assumed to be a hosts-file or domain list)
     sourcedirs = ["sources"]
-    # manual blocklist entries
     # manual whitelist entries - comments for reference
     whitelist = [
         # "getsentry.com",

--- a/doc/src/Configuration.md
+++ b/doc/src/Configuration.md
@@ -29,7 +29,7 @@ questioncachecap = 5000
 
 # manual custom dns entries - comments for reference
 customdnsrecords = [
-    # "example.mywebsite.tld      IN A       10.0.0.1"
+    # "example.mywebsite.tld      IN A       10.0.0.1",
     # "example.other.tld          IN CNAME   wikipedia.org"
 ]
 
@@ -54,7 +54,6 @@ customdnsrecords = [
     # list of locations to recursively read blocklists from (warning, every file found is assumed to be a hosts-file or domain list)
     sourcedirs = ["sources"]
     # manual blocklist entries
-    blocklist = []
     # manual whitelist entries - comments for reference
     whitelist = [
         # "getsentry.com",


### PR DESCRIPTION
Added missing commas to customdnsrecords
Removed duplicate blocklist array, was causing server crash on startup.