### PR TITLE
fix(CI): do not build docker images for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,6 @@ on:
       - 'master'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'master'
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io


### PR DESCRIPTION
issue is external contributors don't have perms to push them. Can still be triggered by a workflow dispatch
