### PR TITLE
fix: add CAP_NET_BIND_SERVICE to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
                 RestartSec = 2;
                 TasksMax = "infinity";
                 StateDirectory = "leng-sources";
+                AmbientCapabilities = "CAP_NET_BIND_SERVICE";
               };
 
               unitConfig = {


### PR DESCRIPTION
Add CAP_NET_BIND_SERVICE capability so leng can bind to port 53 while the service is running as a dynamic user