### PR TITLE
feat/fix: allow disabling high cardinality metrics, and add an option to periodically reset them

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,8 +58,10 @@ type Upstream struct {
 }
 
 type Metrics struct {
-	Enabled bool
-	Path    string
+	Enabled                bool
+	Path                   string
+	HighCardinalityEnabled bool
+	ResetPeriodMinutes     int64
 }
 
 type DnsOverHttpServer struct {
@@ -167,6 +169,9 @@ followCnameDepth = 12
 [Metrics]
 	enabled = false
 	path = "/metrics"
+	# see https://cottand.github.io/leng/Prometheus-Metrics.html
+	highCardinalityEnabled = false
+	resetPeriodMinutes = 60
 
 [DnsOverHttpServer]
 	enabled = false

--- a/doc/src/Configuration.md
+++ b/doc/src/Configuration.md
@@ -103,10 +103,13 @@ customdnsrecords = [
     # cache capacity, 0 for infinite
     maxcount = 0
 
-# Prometheus metrics - enable 
+# Prometheus metrics
 [Metrics]
     enabled = false
     path = "/metrics"
+    # see https://cottand.github.io/leng/Prometheus-Metrics.html
+    highCardinalityEnabled = false
+    resetPeriodMinutes = 60
 
 [DnsOverHttpServer]
     enabled = false

--- a/doc/src/Prometheus-Metrics.md
+++ b/doc/src/Prometheus-Metrics.md
@@ -1,8 +1,41 @@
+# Prometheus metrics
+
 The HTTP API has a `/metrics` endpoint that exposes Go runtime metrics as well as things including:
+
 - downstream DNS requests, broken down by type
 - upstream DNS requests
 - upstream DNS-over-HTTPS success rate
 - downstream DNS-over-HTTPS success rate
 
-
 No grafana dashboards exist for leng yet. If you make one, please make a PR!
+
+## High cardinality metrics
+
+Tags can be added to some metrics (`upstream_request`, `request_total`) so that
+they include information such as the name of the DNS request (ie, `example.com.`)
+or the IP of host making the request.
+
+If leng is left to run for a few hours (and you have enough traffic),
+the cardinality of these metrics will grow, to the point
+the
+size of the `/metrics`
+response will grow to be so big the metrics stop being updated.
+While resetting the counters periodically can help
+(and you can tweak that with the config `Metrics.resetPeriodMinutes`)
+but you might still see issues depending on your traffic.
+You can
+read [this SO post](https://stackoverflow.com/questions/46373442/how-dangerous-are-high-cardinality-labels-in-prometheus)
+to learn more.
+
+High cardinality metrics **can also compromise your privacy** by exposing in the metrics endpoint
+what domains clients are querying as well as their IPs.
+
+For these reasons, **high cardinality metrics are disabled by default**. You can enable them
+with the following config:
+
+```toml
+[Metrics]
+enabled = true
+path = "/metrics"
+highCardinalityEnabled = true
+```

--- a/grimd_test.go
+++ b/grimd_test.go
@@ -62,6 +62,9 @@ func integrationTest(changeConfig func(c *Config), test func(client *dns.Client,
 	// QuestionCache contains all queries to the dns server
 	questionCache := makeQuestionCache(config.QuestionCacheCap)
 
+	reloadChan := make(chan bool)
+	_, _ = StartAPIServer(&config, reloadChan, blockCache, questionCache)
+	defer close(reloadChan)
 	server.Run(&config, blockCache, questionCache)
 
 	time.Sleep(200 * time.Millisecond)

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -73,8 +73,7 @@ var (
 	configHighCardinality = false
 )
 
-func Start(resetPeriodMinutes int64, highCardinality bool) (closeChan context.CancelFunc) {
-	configHighCardinality = highCardinality
+func init() {
 	prometheus.MustRegister(
 		responseCounter,
 		RequestUpstreamResolveCounter,
@@ -82,6 +81,10 @@ func Start(resetPeriodMinutes int64, highCardinality bool) (closeChan context.Ca
 		CustomDNSConfigReload,
 		DohResponseCount,
 	)
+}
+
+func Start(resetPeriodMinutes int64, highCardinality bool) (closeChan context.CancelFunc) {
+	configHighCardinality = highCardinality
 	ctx, cancel := context.WithCancel(context.Background())
 	mark := time.Now()
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/cottand/leng/internal/metric"
 	"golang.org/x/sys/unix"
 	"net/http"
 	"os"
@@ -59,6 +60,8 @@ func main() {
 		loggingState.cleanUp()
 	}()
 
+	cancelMetrics := metric.Start(config.Metrics.ResetPeriodMinutes, config.Metrics.HighCardinalityEnabled)
+
 	lengActive = true
 	quitActivation := make(chan bool)
 	actChannel := make(chan *ActivationHandler)
@@ -103,6 +106,7 @@ forever:
 			case os.Interrupt:
 				logger.Error("SIGINT received, stopping\n")
 				quitActivation <- true
+				cancelMetrics()
 				break forever
 			case unix.SIGHUP:
 				logger.Error("SIGHUP received: rotating logs\n")


### PR DESCRIPTION
This fixes https://github.com/Cottand/leng/issues/50 by periodically resetting the prometheus counters to keep the cardinality in check.

Even though that mitigates the issue greatly, it requires tweaking `Metrics.resetPeriodMinutes` (depending on your traffic).

So I still decided to disable high cardinality metrics by default in order to keep the rest of the metrics working (and protect people's privacy) by default.