### PR TITLE
clean up stateful activation code

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -1,24 +1,11 @@
 package main
 
-// ToggleData type
-type ToggleData struct {
-	Mode uint
-	Data uint
-}
-
 // ActivationHandler type
 type ActivationHandler struct {
-	queryChannel  chan bool
-	toggleChannel chan ToggleData
-	setChannel    chan bool
 }
 
 func startActivation(actChannel chan *ActivationHandler, quit chan bool) {
 	a := &ActivationHandler{}
-
-	a.queryChannel = make(chan bool)
-	a.toggleChannel = make(chan ToggleData)
-	a.setChannel = make(chan bool)
 
 	// put the reference to our struct in the channel
 	// then continue to the loop
@@ -29,18 +16,6 @@ forever:
 		select {
 		case <-quit:
 			break forever
-		case <-a.queryChannel:
-			a.queryChannel <- lengActive
-		case v := <-a.toggleChannel:
-			if v.Mode == 1 {
-				lengActive = !lengActive
-			} else {
-				lengActive = false
-			}
-			a.queryChannel <- lengActive
-		case v := <-a.setChannel:
-			lengActive = v
-			a.setChannel <- lengActive
 		}
 	}
 	logger.Debugf("Activation goroutine exiting")
@@ -49,32 +24,5 @@ forever:
 
 // Query activation state
 func (a ActivationHandler) query() bool {
-	a.queryChannel <- true
-	return <-a.queryChannel
-}
-
-// Set activation state
-func (a ActivationHandler) set(v bool) bool {
-	a.setChannel <- v
-	return <-a.setChannel
-}
-
-// Toggle activation state on or off
-func (a ActivationHandler) toggle(reactivationDelay uint) bool {
-	data := ToggleData{
-		Mode: 1,
-		Data: reactivationDelay,
-	}
-	a.toggleChannel <- data
-	return <-a.queryChannel
-}
-
-// Like toggle(), but only from on to off. Toggling when off will restart the
-// timer.
-func (a ActivationHandler) toggleOff(timeout uint) bool {
-	a.toggleChannel <- ToggleData{
-		Mode: 2,
-		Data: timeout,
-	}
-	return <-a.queryChannel
+	return lengActive
 }

--- a/api.go
+++ b/api.go
@@ -221,42 +221,6 @@ func StartAPIServer(config *Config,
 		c.IndentedJSON(http.StatusOK, gin.H{"active": lengActive})
 	})
 
-	// Handle the setting of active state.
-	// Possible values for state:
-	// On
-	// Off
-	// Snooze: off for `timeout` seconds; timeout defaults to 300
-	router.PUT("/application/active", func(c *gin.Context) {
-		active := c.Query("state")
-		version := c.Query("v")
-		if version != "1" {
-			c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "Illegal value for 'version'"})
-		} else {
-			switch active {
-			case "On":
-				lengActivation.set(true)
-				c.IndentedJSON(http.StatusOK, gin.H{"active": lengActive})
-			case "Off":
-				lengActivation.set(false)
-				c.IndentedJSON(http.StatusOK, gin.H{"active": lengActive})
-			case "Snooze":
-				timeoutString := c.DefaultQuery("timeout", "300")
-				timeout, err := strconv.ParseUint(timeoutString, 0, 0)
-				if err != nil {
-					c.JSON(http.StatusBadRequest, gin.H{"error": "Illegal value for 'timeout'"})
-				} else {
-					lengActivation.toggleOff(uint(timeout))
-					c.IndentedJSON(http.StatusOK, gin.H{
-						"active":  lengActive,
-						"timeout": timeout,
-					})
-				}
-			default:
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Illegal value for 'state'"})
-			}
-		}
-	})
-
 	router.POST("/blocklist/update", func(c *gin.Context) {
 		c.AbortWithStatus(http.StatusOK)
 		// Send reload trigger to chan in background goroutine so does not hang

--- a/grimd_test.go
+++ b/grimd_test.go
@@ -43,7 +43,7 @@ func integrationTest(changeConfig func(c *Config), test func(client *dns.Client,
 	actChannel := make(chan *ActivationHandler)
 
 	go startActivation(actChannel, quitActivation)
-	lengActivation = <-actChannel
+	_ = <-actChannel
 	lengActive = true
 	close(actChannel)
 
@@ -346,7 +346,7 @@ func TestConfigReloadForCustomRecords(t *testing.T) {
 	actChannel := make(chan *ActivationHandler)
 
 	go startActivation(actChannel, quitActivation)
-	lengActivation = <-actChannel
+	_ = <-actChannel
 	close(actChannel)
 
 	server := &Server{

--- a/handler.go
+++ b/handler.go
@@ -123,7 +123,6 @@ func (h *EventLoop) responseFor(Net string, req *dns.Msg, _local net.Addr, _remo
 	q := req.Question[0]
 	Q := Question{UnFqdn(q.Name), dns.TypeToString[q.Qtype], dns.ClassToString[q.Qclass]}
 	logger.Infof("%s lookup　%s\n", remote, Q.String())
-	var lengActive = lengActivation.query()
 
 	IPQuery := h.isIPQuery(q)
 

--- a/main.go
+++ b/main.go
@@ -13,10 +13,9 @@ import (
 )
 
 var (
-	configPath     string
-	forceUpdate    bool
-	lengActive     bool
-	lengActivation *ActivationHandler
+	configPath  string
+	forceUpdate bool
+	lengActive  bool
 )
 
 func reloadBlockCache(config *Config,
@@ -67,7 +66,7 @@ func main() {
 	actChannel := make(chan *ActivationHandler)
 
 	go startActivation(actChannel, quitActivation)
-	lengActivation = <-actChannel
+	_ = <-actChannel
 	close(actChannel)
 
 	server := &Server{


### PR DESCRIPTION
Cleans code left over by the original grimd fork.

Specifically, remove the activation endpoint, which was a stateful on-off switch.