### PR TITLE
test: add integration nixos tests

### DIFF
--- a/nixos-tests/custom-dns.nix
+++ b/nixos-tests/custom-dns.nix
@@ -1,0 +1,44 @@
+{ self, pkgs, home-manager, ... }:
+let
+  nixpkgs = self.inputs.nixpkgs;
+in
+(nixpkgs.lib.nixos.runTest {
+  hostPkgs = pkgs;
+  defaults.documentation.enable = false;
+  node.specialArgs = { inherit self; };
+
+  name = "leng-custom-dns";
+
+  nodes = {
+    server = { config, pkgs, ... }: {
+      imports = [ self.nixosModules.default ];
+      # Open the default port for `postgrest` in the firewall
+      networking.firewall.allowedUDPPorts = [ 53 ];
+
+      services.leng.enable = true;
+      services.leng.configuration = {
+        blocking.sourcesStore = "/tmp";
+        customdnsrecords = [
+          "example.com    IN A   1.2.3.4"
+        ];
+      };
+    };
+
+    client = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.dig ];
+    };
+  };
+
+  testScript =
+    ''
+      start_all()
+
+      server.wait_for_unit("leng", timeout=10)
+      server.wait_for_open_port(53)
+
+      client.succeed(
+        "dig @server example.com | grep -o '1.2.3.4' "
+      )
+    '';
+
+}).config.result

--- a/nixos-tests/metrics-api.nix
+++ b/nixos-tests/metrics-api.nix
@@ -1,0 +1,42 @@
+{ self, pkgs, home-manager, ... }:
+let
+  nixpkgs = self.inputs.nixpkgs;
+  httpPort = 9243;
+in
+(nixpkgs.lib.nixos.runTest {
+  hostPkgs = pkgs;
+  defaults.documentation.enable = false;
+  node.specialArgs = { inherit self; };
+
+  name = "leng-systemctl-start";
+
+  nodes = {
+    server = { config, pkgs, ... }: {
+      imports = [ self.nixosModules.default ];
+      # Open the default port for `postgrest` in the firewall
+      networking.firewall.allowedTCPPorts = [ httpPort ];
+
+      services.leng.enable = true;
+      services.leng.configuration = {
+        metrics.enabled = true;
+        api = "0.0.0.0:${toString httpPort}";
+        blocking.sourcesStore="/tmp";
+      };
+    };
+
+    client = {};
+  };
+
+  testScript =
+    ''
+      start_all()
+
+      server.wait_for_unit("leng", timeout=10)
+      server.wait_for_open_port(${toString httpPort})
+
+      actual = client.succeed(
+        "curl http://server:${toString httpPort}/metrics | grep -o 'go_gc_duration_seconds' "
+      )
+    '';
+
+}).config.result

--- a/nixos-tests/systemctl-start.nix
+++ b/nixos-tests/systemctl-start.nix
@@ -1,0 +1,34 @@
+{ self, pkgs, home-manager, ... }:
+let
+  nixpkgs = self.inputs.nixpkgs;
+in
+(nixpkgs.lib.nixos.runTest {
+  hostPkgs = pkgs;
+  defaults.documentation.enable = false;
+  node.specialArgs = { inherit self; };
+
+  name = "leng-metrics-api";
+
+  nodes = {
+    server = { config, pkgs, ... }: {
+      imports = [ self.nixosModules.default ];
+
+      services.leng.enable = true;
+      services.leng.configuration = {
+        blocking.sourcesStore="/tmp";
+      };
+    };
+
+    client = { };
+  };
+
+  testScript =
+    ''
+      start_all()
+
+      server.wait_for_unit("leng", timeout=10)
+
+      server.succeed("systemctl status leng")
+    '';
+
+}).config.result


### PR DESCRIPTION
Adds integration tests that spin up a VM to test systemctl start, DNS and metrics APIs

These are meant to be the base for more complex tests in the future, to hopefully narrow down issues like https://github.com/Cottand/leng/issues/55.

This PR also changes the NixOS module to allow for more paths for the sources database.