### PR TITLE
metrics: histogram for upstream resolve duration

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,6 +62,7 @@ type Metrics struct {
 	Path                   string
 	HighCardinalityEnabled bool
 	ResetPeriodMinutes     int64
+	HistogramsEnabled      bool
 }
 
 type DnsOverHttpServer struct {
@@ -111,6 +112,9 @@ interval = 200
 
 # question cache capacity, 0 for infinite but not recommended (this is used for storing logs)
 questioncachecap = 5000
+
+# timeout for upstream DNS queries, in ms
+timeout = 5000
 
 # manual whitelist entries - comments for reference
 whitelist = [
@@ -170,6 +174,7 @@ followCnameDepth = 12
 	path = "/metrics"
 	# see https://cottand.github.io/leng/Prometheus-Metrics.html
 	highCardinalityEnabled = false
+    histogramsEnabled = false
 	resetPeriodMinutes = 60
 
 [DnsOverHttpServer]

--- a/grimd_test.go
+++ b/grimd_test.go
@@ -37,7 +37,7 @@ func integrationTest(changeConfig func(c *Config), test func(client *dns.Client,
 
 	changeConfig(&config)
 
-	cancelMetrics := metric.Start(config.Metrics.ResetPeriodMinutes, config.Metrics.HighCardinalityEnabled)
+	cancelMetrics := metric.Start(config.Metrics.ResetPeriodMinutes, config.Metrics.HighCardinalityEnabled, false)
 	defer cancelMetrics()
 	quitActivation := make(chan bool)
 	actChannel := make(chan *ActivationHandler)

--- a/main.go
+++ b/main.go
@@ -59,7 +59,11 @@ func main() {
 		loggingState.cleanUp()
 	}()
 
-	cancelMetrics := metric.Start(config.Metrics.ResetPeriodMinutes, config.Metrics.HighCardinalityEnabled)
+	cancelMetrics := metric.Start(
+		config.Metrics.ResetPeriodMinutes,
+		config.Metrics.HighCardinalityEnabled,
+		config.Metrics.HistogramsEnabled,
+	)
 
 	lengActive = true
 	quitActivation := make(chan bool)


### PR DESCRIPTION
adds metric `leng_upstream_request_duration_*` metrics to keep track of duration of upstream resolving