### PR TITLE
api: (BREAKING) remove question cache

### DIFF
--- a/api.go
+++ b/api.go
@@ -162,6 +162,27 @@ func StartAPIServer(config *Config, reloadChan chan bool, blockCache *MemoryBloc
 		}
 	})
 
+	router.GET("/questioncache", func(c *gin.Context) {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "invalid request - endpoint has been deprecated"})
+	})
+
+	router.GET("/questioncache/length", func(c *gin.Context) {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "invalid request - endpoint has been deprecated"})
+	})
+
+	router.GET("/questioncache/clear", func(c *gin.Context) {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "invalid request - endpoint has been deprecated"})
+	})
+
+	router.GET("/questioncache/client/:client", func(c *gin.Context) {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "invalid request - endpoint has been deprecated"})
+	})
+
+	router.GET("/questioncache/client", func(c *gin.Context) {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "invalid request - endpoint has been deprecated"})
+
+	})
+
 	router.OPTIONS("/application/active", func(c *gin.Context) {
 		c.AbortWithStatus(http.StatusOK)
 	})

--- a/api.go
+++ b/api.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -30,10 +29,7 @@ func isRunningInDockerContainer() bool {
 }
 
 // StartAPIServer starts the API server
-func StartAPIServer(config *Config,
-	reloadChan chan bool,
-	blockCache *MemoryBlockCache,
-	questionCache *MemoryQuestionCache) (*http.Server, error) {
+func StartAPIServer(config *Config, reloadChan chan bool, blockCache *MemoryBlockCache) (*http.Server, error) {
 	if !config.APIDebug {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -164,56 +160,6 @@ func StartAPIServer(config *Config,
 				logger.Error(err)
 			}
 		}
-	})
-
-	router.GET("/questioncache", func(c *gin.Context) {
-		highWater, err := strconv.ParseInt(c.DefaultQuery("highWater", "-1"), 10, 64)
-		if err != nil {
-			highWater = -1
-		}
-		c.IndentedJSON(http.StatusOK, gin.H{
-			"length": questionCache.Length(),
-			"items":  questionCache.GetOlder(highWater),
-		})
-	})
-
-	router.GET("/questioncache/length", func(c *gin.Context) {
-		c.IndentedJSON(http.StatusOK, gin.H{"length": questionCache.Length()})
-	})
-
-	router.GET("/questioncache/clear", func(c *gin.Context) {
-		questionCache.Clear()
-		c.IndentedJSON(http.StatusOK, gin.H{"success": true})
-	})
-
-	router.GET("/questioncache/client/:client", func(c *gin.Context) {
-		var filteredCache []QuestionCacheEntry
-
-		questionCache.mu.RLock()
-		for _, entry := range questionCache.Backend {
-			if entry.Remote == c.Param("client") {
-				filteredCache = append(filteredCache, entry)
-			}
-		}
-		questionCache.mu.RUnlock()
-
-		c.IndentedJSON(http.StatusOK, filteredCache)
-	})
-
-	router.GET("/questioncache/client", func(c *gin.Context) {
-		clientList := make(map[string]bool)
-		questionCache.mu.RLock()
-		for _, entry := range questionCache.Backend {
-			if _, ok := clientList[entry.Remote]; !ok {
-				clientList[entry.Remote] = true
-			}
-		}
-		questionCache.mu.RUnlock()
-		var clients []string
-		for client := range clientList {
-			clients = append(clients, client)
-		}
-		c.IndentedJSON(http.StatusOK, clients)
 	})
 
 	router.OPTIONS("/application/active", func(c *gin.Context) {

--- a/cache.go
+++ b/cache.go
@@ -73,13 +73,6 @@ type MemoryBlockCache struct {
 	mu      sync.RWMutex
 }
 
-// MemoryQuestionCache type
-type MemoryQuestionCache struct {
-	Backend  []QuestionCacheEntry `json:"entry"`
-	Maxcount int
-	mu       sync.RWMutex
-}
-
 // Get returns the entry for a key or an error
 func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 	key = strings.ToLower(key)
@@ -277,40 +270,4 @@ func (c *MemoryBlockCache) Length() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return len(c.Backend)
-}
-
-// Add adds a question to the cache
-func (c *MemoryQuestionCache) Add(q QuestionCacheEntry) {
-	c.mu.Lock()
-	if c.Maxcount != 0 && len(c.Backend) >= c.Maxcount {
-		c.Backend = nil
-	}
-	c.Backend = append(c.Backend, q)
-	c.mu.Unlock()
-}
-
-// Clear clears the contents of the cache
-func (c *MemoryQuestionCache) Clear() {
-	c.mu.Lock()
-	c.Backend = make([]QuestionCacheEntry, 0, 0)
-	c.mu.Unlock()
-}
-
-// Length returns the caches length
-func (c *MemoryQuestionCache) Length() int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.Backend)
-}
-
-// GetOlder eturns a slice of the entries older than `time`
-func (c *MemoryQuestionCache) GetOlder(time int64) []QuestionCacheEntry {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	for i, e := range c.Backend {
-		if e.Date > time {
-			return c.Backend[i:]
-		}
-	}
-	return []QuestionCacheEntry{}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -296,31 +296,6 @@ func TestExpirationRace(t *testing.T) {
 }
 */
 
-func addToCache(cache *MemoryQuestionCache, time int64) {
-	cache.Add(QuestionCacheEntry{
-		Date:    time,
-		Remote:  fmt.Sprintf("%d", time),
-		Blocked: true,
-		Query:   Question{},
-	})
-}
-
-func TestQuestionCacheGetFromTimestamp(t *testing.T) {
-	memCache := makeQuestionCache(100)
-	for i := 0; i < 100; i++ {
-		addToCache(memCache, int64(i))
-	}
-
-	entries := memCache.GetOlder(50)
-	assert.Len(t, entries, 49)
-	entries = memCache.GetOlder(0)
-	assert.Len(t, entries, 99)
-	entries = memCache.GetOlder(-1)
-	assert.Len(t, entries, 100)
-	entries = memCache.GetOlder(200)
-	assert.Len(t, entries, 0)
-}
-
 func BenchmarkSetCache(b *testing.B) {
 	cache := makeCache()
 

--- a/grimd_test.go
+++ b/grimd_test.go
@@ -59,13 +59,11 @@ func integrationTest(changeConfig func(c *Config), test func(client *dns.Client,
 	for _, blocked := range config.Blocking.Blocklist {
 		_ = blockCache.Set(blocked, true)
 	}
-	// QuestionCache contains all queries to the dns server
-	questionCache := makeQuestionCache(config.QuestionCacheCap)
 
 	reloadChan := make(chan bool)
-	_, _ = StartAPIServer(&config, reloadChan, blockCache, questionCache)
+	_, _ = StartAPIServer(&config, reloadChan, blockCache)
 	defer close(reloadChan)
-	server.Run(&config, blockCache, questionCache)
+	server.Run(&config, blockCache)
 
 	time.Sleep(200 * time.Millisecond)
 	defer server.Stop()
@@ -358,10 +356,8 @@ func TestConfigReloadForCustomRecords(t *testing.T) {
 
 	// BlockCache contains all blocked domains
 	blockCache := &MemoryBlockCache{Backend: make(map[string]bool)}
-	// QuestionCache contains all queries to the dns server
-	questionCache := makeQuestionCache(config.QuestionCacheCap)
 
-	server.Run(&config, blockCache, questionCache)
+	server.Run(&config, blockCache)
 
 	time.Sleep(200 * time.Millisecond)
 	defer server.Stop()

--- a/server.go
+++ b/server.go
@@ -22,13 +22,9 @@ type Server struct {
 }
 
 // Run starts the server
-func (s *Server) Run(
-	config *Config,
-	blockCache *MemoryBlockCache,
-	questionCache *MemoryQuestionCache,
-) {
+func (s *Server) Run(config *Config, blockCache *MemoryBlockCache) {
 
-	s.eventLoop = NewEventLoop(config, blockCache, questionCache)
+	s.eventLoop = NewEventLoop(config, blockCache)
 
 	tcpHandler := dns.NewServeMux()
 	tcpHandler.HandleFunc(".", s.eventLoop.DoTCP)

--- a/utils.go
+++ b/utils.go
@@ -7,10 +7,6 @@ func makeCache() MemoryCache {
 	}
 }
 
-func makeQuestionCache(maxCount int) *MemoryQuestionCache {
-	return &MemoryQuestionCache{Backend: make([]QuestionCacheEntry, 0), Maxcount: maxCount}
-}
-
 // Difference between to lists: A - B
 func difference[T comparable](a, b []T) (diff []T) {
 	m := make(map[T]bool)


### PR DESCRIPTION
This removes a feature inherited from grimd, which keeps
track of historic dns queries and exposed them in the API.

This is not to be confised with the response cache (which caches DNS queries' responses).

The question 'cache' keeps only DNS questions and is not functional to answering DNS queries.

Since inheriting this feature, leng now has metrics which achieve similar functionality - only it exposes it via a different API (prometheus).

Thes endpoints are thus now deprecated.
