### PR TITLE
test: add ad-hoc darwin VM for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ leng.toml
 .DS_Store
 
 result
+*.qcow2

--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,30 @@
             ];
           };
         };
+
+
+      # this is a simple NixOS VM that can be used for trying out the NixOS module outside of a NixOS test
+      nixosConfigurations.aarch-darwin-leng-test = nixpkgs.lib.nixosSystem {
+        system = "aarch64-linux";
+        modules = [
+          self.nixosModules.default
+          {
+            virtualisation.vmVariant.virtualisation.graphics = false;
+            virtualisation.vmVariant.virtualisation.host.pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+            services.getty.autologinUser = "root";
+            system.stateVersion = "24.11";
+
+            services.leng = {
+              enable = true;
+              configuration = {
+                api = "127.0.0.1:8080";
+                metrics.enabled = true;
+                blocking.sourcesStore = "/var/lib/leng-sources";
+              };
+            };
+          }
+        ];
+      };
     };
 }
 


### PR DESCRIPTION
This is not used in any automated tests, but rather to create a reproducible environment to test configurations on.
